### PR TITLE
Restrict command execution to server console only to mitigate potential security risks.

### DIFF
--- a/lua/azlink/azlink.lua
+++ b/lua/azlink/azlink.lua
@@ -1,4 +1,4 @@
-﻿AZLINK_VERSION = "1.0.0"
+﻿AZLINK_VERSION = "1.0.1"
 
 AzLink = AzLink or { }
 AzLink.lastSent = 0

--- a/lua/azlink/commands/azlink_command.lua
+++ b/lua/azlink/commands/azlink_command.lua
@@ -10,7 +10,7 @@ end
 
 concommand.Add( "azlink", function( ply, _, args )
     if IsValid( ply ) then
-        ply:SendLua( [[MsgC(Color(255,0,0),"[AzLink - ERROR] ",color_white,"This command must be executed from the server console.")]] )
+        ply:SendLua( [[MsgC(Color(255,0,0),"[AzLink - ERROR] ",color_white,"This command must be executed from the server console.","\n")]] )
         return
     end
 

--- a/lua/azlink/commands/azlink_command.lua
+++ b/lua/azlink/commands/azlink_command.lua
@@ -10,7 +10,7 @@ end
 
 concommand.Add( "azlink", function( ply, _, args )
     if IsValid( ply ) then
-        ply:SendLua( [[MsgC(Color(255,0,0),"[AzLink - ERROR] ",color_white,"This command must be executed from the server console.","\n")]] )
+        ply:PrintMessage( HUD_PRINTCONSOLE, "This command must be executed from the server console." )
         return
     end
 

--- a/lua/azlink/commands/azlink_command.lua
+++ b/lua/azlink/commands/azlink_command.lua
@@ -8,7 +8,12 @@
     end )
 end
 
-concommand.Add( "azlink", function( _, _, args )
+concommand.Add( "azlink", function( ply, _, args )
+    if IsValid( ply ) then
+        ply:SendLua( [[MsgC(Color(255,0,0),"[AzLink - ERROR] ",color_white,"This command must be executed from the server console.")]] )
+        return
+    end
+
     if args[2] == "setup" then
         if args[3] == nil or args[4] == nil then
             AzLink.Logger:Error( "You must first add this server in your Azuriom admin dashboard, in the 'Servers' section." )


### PR DESCRIPTION
If not checking the command executor, anyone can execute the command and modify the server settings.